### PR TITLE
Enabled rectilinear interpolation. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 *.so
 *.egg-info/
 **/.mypy_cache/
+env/

--- a/test/test_linear_interpolation.py
+++ b/test/test_linear_interpolation.py
@@ -1,6 +1,6 @@
 import torch
 import torchcde
-import unittest
+import pytest
 
 
 def test_random():
@@ -117,69 +117,72 @@ def test_specification_and_derivative():
                         assert derivative.allclose(autoderivative, atol=1e-5, rtol=1e-5)
 
 
-def test_rectilinear_preparation(self):
-    # Simple test
-    nan = float('nan')
-    t1 = torch.tensor([0.1, 0.2, 0.9]).view(-1, 1)
-    t2 = torch.tensor([0.2, 0.3]).view(-1, 1)
-    x1 = torch.tensor([0.4, nan, 1.1]).view(-1, 1)
-    x2 = torch.tensor([nan, 2.]).view(-1, 1)
-    x = torch.nn.utils.rnn.pad_sequence(
-        [torch.cat((t1, x1), -1), torch.cat((t2, x2), -1)], batch_first=True, padding_value=nan
-    )
-    x1_true = torch.tensor([[0.1, 0.2, 0.2, 0.9, 0.9], [0.4, 0.4, 0.4, 0.4, 1.1]]).T.view(-1, 2)
-    x2_true = torch.tensor([[0.2, 0.3, 0.3, 0.3, 0.3], [2., 2., 2., 2., 2.]]).T.view(-1, 2)
-    rect_true = torch.stack((x1_true, x2_true))
-    rectilinear = torchcde.linear_interpolation_coeffs(x, rectilinear=0)
-    assert torch.equal(rect_true[~torch.isnan(rect_true)], rectilinear[~torch.isnan(rectilinear)])
-    # Test also if we swap time time dimension
-    x_swap = x[:, :, [1, 0]]
-    rectilinear_swap = torchcde.linear_interpolation_coeffs(x_swap, rectilinear=1)
-    rect_swp = rect_true[:, :, [1, 0]]
-    assert torch.equal(rect_swp, rectilinear_swap)
+def test_rectilinear_preparation():
+    devices = ['cpu']
+    if torch.cuda.is_available():
+        devices.append('cuda')
 
-    # Additionally try a 2d case
-    assert torch.equal(rect_true[0], torchcde.linear_interpolation_coeffs(x[0], rectilinear=0))
-    # And a 4d case
-    x_4d = torch.stack([x, x])
-    rect_true_4d = torch.stack([rect_true, rect_true])
-    assert torch.equal(rect_true_4d, torchcde.linear_interpolation_coeffs(x_4d, rectilinear=0))
-
-    # Ensure error is thrown if time has a nan value between real values
-    x_time_nan = x.clone()
-    x_time_nan[0, 1, 0] = float('nan')
-    try:
-        torchcde.linear_interpolation_coeffs(x_time_nan, rectilinear=0)
-    except AssertionError:
-        pass
-
-    # Some randoms tests
-    n_channels = 10
-    for _ in range(5):
-        # Build some data with time
-        t_starts = torch.randn(5) ** 2
-        ts = [torch.linspace(t_start, t_start + 10, torch.randint(0, 50, (1,)).item()) for t_start in t_starts]
-        xs = [torch.randn(len(t), n_channels - 1) for t in ts]
+    for device in devices:
+        # Simple test
+        nan = float('nan')
+        t1 = torch.tensor([0.1, 0.2, 0.9]).view(-1, 1).to(device)
+        t2 = torch.tensor([0.2, 0.3]).view(-1, 1).to(device)
+        x1 = torch.tensor([0.4, nan, 1.1]).view(-1, 1).to(device)
+        x2 = torch.tensor([nan, 2.]).view(-1, 1).to(device)
         x = torch.nn.utils.rnn.pad_sequence(
-            [torch.cat([t_.view(-1, 1), x_], dim=1) for t_, x_ in zip(ts, xs)], batch_first=True, padding_value=nan
+            [torch.cat((t1, x1), -1), torch.cat((t2, x2), -1)], batch_first=True, padding_value=nan
         )
-        # Add some random nans about the place
-        mask = torch.randint(0, 5, (x.size(0), x.size(1), x.size(2) - 1), dtype=torch.float)
-        mask[mask == 0] = float('nan')
-        x[:, :, 1:] = x[:, :, 1:] * mask
-        # Fill
-        x_ffilled = torchcde.misc.forward_fill(x)
-        # Compute the true solution
-        N, L, C = x_ffilled.shape
-        rect_true = torch.zeros(N, 2 * L - 1, C)
-        lag = torch.cat([x_ffilled[:, 1:, [0]], x_ffilled[:, :-1, 1:]], dim=-1)
-        rect_true[:, ::2, ] = x_ffilled
-        rect_true[:, 1::2] = lag
-        # Need to backfill rect true
-        # Rectilinear solution
+        # We have to fill the time index forward because we currently dont allow nan times for rectilinear
+        x[:, :, 0] = torchcde.misc.forward_fill(x[:, :, 0], fill_index=-1)
+        # Build true solution
+        x1_true = torch.tensor([[0.1, 0.2, 0.2, 0.9, 0.9], [0.4, 0.4, 0.4, 0.4, 1.1]]).T.view(-1, 2).to(device)
+        x2_true = torch.tensor([[0.2, 0.3, 0.3, 0.3, 0.3], [2., 2., 2., 2., 2.]]).T.view(-1, 2).to(device)
+        rect_true = torch.stack((x1_true, x2_true))
+        # Apply rectilinear and compare
         rectilinear = torchcde.linear_interpolation_coeffs(x, rectilinear=0)
-        assert torch.equal(rect_true, rectilinear)
+        assert torch.equal(rect_true[~torch.isnan(rect_true)], rectilinear[~torch.isnan(rectilinear)])
+        # Test also if we swap time time dimension
+        x_swap = x[:, :, [1, 0]]
+        rectilinear_swap = torchcde.linear_interpolation_coeffs(x_swap, rectilinear=1)
+        rect_swp = rect_true[:, :, [1, 0]]
+        assert torch.equal(rect_swp, rectilinear_swap)
 
+        # Additionally try a 2d case
+        assert torch.equal(rect_true[0], torchcde.linear_interpolation_coeffs(x[0], rectilinear=0))
+        # And a 4d case
+        x_4d = torch.stack([x, x])
+        rect_true_4d = torch.stack([rect_true, rect_true])
+        assert torch.equal(rect_true_4d, torchcde.linear_interpolation_coeffs(x_4d, rectilinear=0))
 
-if __name__ == '__main__':
-    test_rectilinear_preparation()
+        # Ensure error is thrown if time has a nan value anywhere
+        x_time_nan = x.clone()
+        x_time_nan[0, 1, 0] = float('nan')
+        pytest.raises(AssertionError, torchcde.linear_interpolation_coeffs, x_time_nan, rectilinear=0)
+
+        # Some randoms tests
+        for _ in range(5):
+            # Build some data with time
+            t_starts = torch.randn(5).to(device) ** 2
+            ts = [torch.linspace(s, s + 10, torch.randint(2, 50, (1,)).item()).to(device) for s in t_starts]
+            xs = [torch.randn(len(t), 10 - 1).to(device) for t in ts]
+            x = torch.nn.utils.rnn.pad_sequence(
+                [torch.cat([t_.view(-1, 1), x_], dim=1) for t_, x_ in zip(ts, xs)], batch_first=True, padding_value=nan
+            )
+            # Add some random nans about the place
+            mask = torch.randint(0, 5, (x.size(0), x.size(1), x.size(2) - 1), dtype=torch.float).to(device)
+            mask[mask == 0] = float('nan')
+            x[:, :, 1:] = x[:, :, 1:] * mask
+            # We have to fill the time index forward because we currently dont allow nan times for rectilinear
+            x[:, :, 0] = torchcde.misc.forward_fill(x[:, :, 0], fill_index=-1)
+            # Fill
+            x_ffilled = torchcde.misc.forward_fill(x)
+            # Compute the true solution
+            N, L, C = x_ffilled.shape
+            rect_true = torch.zeros(N, 2 * L - 1, C).to(device)
+            lag = torch.cat([x_ffilled[:, 1:, [0]], x_ffilled[:, :-1, 1:]], dim=-1)
+            rect_true[:, ::2, ] = x_ffilled
+            rect_true[:, 1::2] = lag
+            # Need to backfill rect true
+            # Rectilinear solution
+            rectilinear = torchcde.linear_interpolation_coeffs(x, rectilinear=0)
+            assert torch.equal(rect_true[~torch.isnan(rect_true)], rectilinear[~torch.isnan(rect_true)])

--- a/test/test_linear_interpolation.py
+++ b/test/test_linear_interpolation.py
@@ -114,3 +114,49 @@ def test_specification_and_derivative():
                         autoderivative = torch.stack(autoderivative).view(*evaluate.shape)
                         assert derivative.shape == autoderivative.shape
                         assert derivative.allclose(autoderivative, atol=1e-5, rtol=1e-5)
+
+
+def test_rectilinear_preparation():
+    # Some fucntions
+    pad_sequence = lambda sequences: torch.nn.utils.rnn.pad_sequence(sequences, batch_first=True, padding_value=nan)
+    ffill = torchcde.misc.torch_ffill
+
+    # Simple test
+    nan = float('nan')
+    t1 = torch.Tensor([0.1, 0.2, 0.9]).view(-1, 1)
+    t2 = torch.Tensor([0.2, 0.3]).view(-1, 1)
+    x1 = torch.Tensor([0.4, nan, 1.1]).view(-1, 1)
+    x2 = torch.Tensor([nan, 2.]).view(-1, 1)
+    x = pad_sequence([torch.cat((t1, x1), -1), torch.cat((t2, x2), -1)])
+    x1_true = torch.Tensor([[0.1, 0.2, 0.2, 0.9, 0.9], [0.4, 0.4, 0.4, 0.4, 1.1]]).T.view(-1, 2)
+    x2_true = torch.Tensor([[0.2, 0.3, 0.3], [nan, nan, 2.]]).T.view(-1, 2)
+    rect_true = ffill(pad_sequence([x1_true, x2_true]))
+    rectilinear = torchcde.interpolation_linear._prepare_rectilinear_interpolation(x, 0)
+    assert rect_true.allclose(rectilinear, equal_nan=True)
+    # Test also if we swap time time dimension
+    x_swap = x[:, :, [1, 0]]
+    rectilinear_swap = torchcde.interpolation_linear._prepare_rectilinear_interpolation(x_swap, 1)
+    assert ffill(rect_true[:, :, [1, 0]]).allclose(rectilinear_swap, equal_nan=True)
+
+    n_channels = 10
+    for _ in range(5):
+        # Build some data with time
+        t_starts = torch.randn(5) ** 2
+        ts = [torch.linspace(t_start, t_start + 10, torch.randint(0, 50, (1,)).item()) for t_start in t_starts]
+        xs = [torch.randn(len(t), n_channels - 1) for t in ts]
+        x = pad_sequence([torch.cat([t_.view(-1, 1), x_], 1) for t_, x_ in zip(ts, xs)])
+        # Add some random nans about the place
+        mask = torch.randint(0, 5, (x.size(0), x.size(1), x.size(2) - 1)).to(float)
+        mask[mask == 0] = float('nan')
+        x[:, :, 1:] = x[:, :, 1:] * mask
+        # Fill
+        x_ffilled = ffill(x)
+        # Compute the true solution
+        N, L, C = x_ffilled.shape
+        rect_true = torch.zeros(N, 2 * L - 1, C)
+        lag = torch.cat([x_ffilled[:, 1:, [0]], x_ffilled[:, :-1, 1:]], -1)
+        rect_true[:, ::2, ] = x_ffilled
+        rect_true[:, 1::2] = lag
+        # Rectilinear solution
+        rectilinear = torchcde.interpolation_linear._prepare_rectilinear_interpolation(x, 0)
+        assert rect_true.allclose(rectilinear, equal_nan=True)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -29,18 +29,29 @@ def test_tridiagonal_solve():
 
 
 def test_forward_fill():
-    for N, L, C in [(1, 2, 3), (2, 2, 2), (3, 2, 1)]:
-        x = torch.randn(N, L, C)
-        # Drop mask
-        tensor_num = x.numel()
-        mask = torch.randperm(tensor_num)[:int(0.3 * tensor_num)]
-        x.view(-1)[mask] = float('nan')
-        x_ffilled = x.clone().float()
-        for i in range(0, x.size(0)):
-            for j in range(x.size(1)):
-                for k in range(x.size(2)):
-                    non_nan = x_ffilled[i, :j + 1, k][~torch.isnan(x[i, :j + 1, k])]
-                    input_val = non_nan[-1].item() if len(non_nan) > 0 else float('nan')
-                    x_ffilled[i, j, k] = input_val
-        x_ffilled_actual = torchcde.misc.forward_fill(x)
-        assert x_ffilled.allclose(x_ffilled_actual, equal_nan=True)
+    devices = ['cpu']
+    if torch.cuda.is_available():
+        devices.append('cuda')
+
+    for device in devices:
+        # Check indices returns
+        indices_check = torch.tensor([False, False, True, True]).to(device).cummax(0).indices
+        desired_indices = torch.tensor([0, 1, 2, 3]).to(device)
+        assert torch.equal(indices_check, desired_indices)
+
+        # Check ffill
+        for N, L, C in [(1, 5, 3), (2, 2, 2), (3, 2, 1)]:
+            x = torch.randn(N, L, C).to(device)
+            # Drop mask
+            tensor_num = x.numel()
+            mask = torch.randperm(tensor_num)[:int(0.3 * tensor_num)].to(device)
+            x.view(-1)[mask] = float('nan')
+            x_ffilled = x.clone().float()
+            for i in range(0, x.size(0)):
+                for j in range(x.size(1)):
+                    for k in range(x.size(2)):
+                        non_nan = x_ffilled[i, :j + 1, k][~torch.isnan(x[i, :j + 1, k])]
+                        input_val = non_nan[-1].item() if len(non_nan) > 0 else float('nan')
+                        x_ffilled[i, j, k] = input_val
+            x_ffilled_actual = torchcde.misc.forward_fill(x)
+            assert x_ffilled.allclose(x_ffilled_actual, equal_nan=True)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -28,12 +28,13 @@ def test_tridiagonal_solve():
         assert mul.allclose(b)
 
 
-def test_ffill():
+def test_forward_fill():
     for N, L, C in [(1, 2, 3), (2, 2, 2), (3, 2, 1)]:
         x = torch.randn(N, L, C)
-        mask = torch.randint(0, 2, x.size()).to(float)
-        mask[mask == 0] = float('nan')
-        x = x * mask
+        # Drop mask
+        tensor_num = x.numel()
+        mask = torch.randperm(tensor_num)[:int(0.3 * tensor_num)]
+        x.view(-1)[mask] = float('nan')
         x_ffilled = x.clone().float()
         for i in range(0, x.size(0)):
             for j in range(x.size(1)):
@@ -41,5 +42,5 @@ def test_ffill():
                     non_nan = x_ffilled[i, :j + 1, k][~torch.isnan(x[i, :j + 1, k])]
                     input_val = non_nan[-1].item() if len(non_nan) > 0 else float('nan')
                     x_ffilled[i, j, k] = input_val
-        x_ffilled_actual = torchcde.misc.torch_ffill(x)
+        x_ffilled_actual = torchcde.misc.forward_fill(x)
         assert x_ffilled.allclose(x_ffilled_actual, equal_nan=True)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -34,11 +34,6 @@ def test_forward_fill():
         devices.append('cuda')
 
     for device in devices:
-        # Check indices returns as expected
-        indices_check = torch.tensor([False, False, True, True, False]).to(device).cummax(0).indices
-        desired_indices = torch.tensor([0, 1, 2, 3, 3]).to(device)
-        assert torch.equal(indices_check, desired_indices)
-
         # Check ffill
         for N, L, C in [(1, 5, 3), (2, 2, 2), (3, 2, 1)]:
             x = torch.randn(N, L, C).to(device)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -34,9 +34,9 @@ def test_forward_fill():
         devices.append('cuda')
 
     for device in devices:
-        # Check indices returns
-        indices_check = torch.tensor([False, False, True, True]).to(device).cummax(0).indices
-        desired_indices = torch.tensor([0, 1, 2, 3]).to(device)
+        # Check indices returns as expected
+        indices_check = torch.tensor([False, False, True, True, False]).to(device).cummax(0).indices
+        desired_indices = torch.tensor([0, 1, 2, 3, 3]).to(device)
         assert torch.equal(indices_check, desired_indices)
 
         # Check ffill

--- a/torchcde/interpolation_linear.py
+++ b/torchcde/interpolation_linear.py
@@ -82,7 +82,51 @@ def _linear_interpolation_coeffs_with_missing_values(t, x):
         return misc.cheap_stack(out_pieces, dim=0)
 
 
-def linear_interpolation_coeffs(x, t=None):
+def _prepare_rectilinear_interpolation(data, time_index):
+    """Prepares data for rectilinear interpolation.
+
+    This function performs the relevant filling and lagging of the data needed to convert raw data into a format such
+    standard linear interpolation will give the rectilinear interpolation.
+
+    Arguments:
+        x: tensor of values with first channel index being time, of shape (..., length, input_channels), where ... is
+            some number of batch dimensions.
+        time_index: integer giving the index of the time channel.
+
+    Example:
+        Suppose we have data:
+            data = [(t1, x1), (t2, NaN), (t3, x3), ...]
+        that we wish to interpolate using a rectilinear scheme. The key point is that this is equivalent to a linear
+        interpolation on
+            data_rect = [(t1, x1), (t2, x1), (t2, x1), (t3, x1), (t3, x3) ...]
+        This function simply performs the conversion from `data` to `data_rect` so that we can apply the inbuilt
+        torchcde linear interpolation scheme to achieve rectilinear interpolation.
+
+    Returns:
+        A tensor, now of shape [N, 2*L - 1, C] that can be fed to linear interpolation coeffs to give rectilinear
+            coeffs.
+    """
+    # Check time_index is of the correct format
+    n_channels = data.size(2)
+    assert isinstance(time_index, int), "Index of the time channel must be an integer in [0, {}]".format(n_channels)
+    assert 0 <= time_index < data.size(2), "Time index must be in [0, {}], was given {}.".format(n_channels, time_index)
+    # Check the specified channel dim does not violate time conditions
+    times = data[:, :, time_index]
+    time_diffs = times[:, 1:] - times[:, :1]
+    assert time_diffs[~torch.isnan(time_diffs)].min() > 0, "Found consecutive times with a difference <= 0." \
+                                                           "Please ensure that data[:, :, 0] corresponds to times " \
+                                                           "and ensure that they are increasing for each sample."
+
+    # Forward fill and perform lag interleaving for rectilinear
+    data_filled = misc.torch_ffill(data)
+    data_repeat = data_filled.repeat_interleave(2, dim=1)
+    data_repeat[:, :-1, time_index] = data_repeat[:, 1:, time_index]
+    data_rect = data_repeat[:, :-1]
+
+    return data_rect
+
+
+def linear_interpolation_coeffs(x, t=None, rectilinear=None):
     """Calculates the knots of the linear interpolation of the batch of controls given.
 
     Arguments:
@@ -91,6 +135,9 @@ def linear_interpolation_coeffs(x, t=None):
             length-many observations. Missing values are supported, and should be represented as NaNs.
         t: Optional one dimensional tensor of times. Must be monotonically increasing. If not passed will default to
             tensor([0., 1., ..., length - 1]).
+        rectilinear: Optional integer. Used for performing rectilinear interpolation. Default is None which results in
+            standard linear interpolation. For rectilinear interpolation time *must* be a channel in x and the
+            `rectilinear` parameter must be an integer specifying the channel index location of the time index in x.
 
     In particular, the support for missing values allows for batching together elements that are observed at
     different times; just set them to have missing values at each other's observation times.
@@ -106,6 +153,9 @@ def linear_interpolation_coeffs(x, t=None):
         way.
     """
     t = misc.validate_input_path(x, t)
+
+    if rectilinear is not None:
+        x = _prepare_rectilinear_interpolation(x, rectilinear)
 
     if torch.isnan(x).any():
         x = _linear_interpolation_coeffs_with_missing_values(t, x.transpose(-1, -2)).transpose(-1, -2)

--- a/torchcde/misc.py
+++ b/torchcde/misc.py
@@ -119,3 +119,34 @@ def validate_input_path(x, t):
                          "time dimension of size {}.".format(tuple(t.shape), t.size(0)))
 
     return t
+
+
+def torch_ffill(data):
+    """Forward fills data in a torch tensor of shape [N, L, C] along the L dim.
+
+    Args:
+        data (torch.Tensor):
+
+    Returns:
+
+    """
+    # Checks
+    assert isinstance(data, torch.Tensor)
+    assert data.dim() == 3
+
+    # Function to fill a 2d tensor
+    def fill2d(x):
+        """ Forward fills in the L dimension if L is of shape [L, N]. """
+        mask = np.isnan(x)
+        idx = np.where(~mask, np.arange(mask.shape[1]), 0)
+        np.maximum.accumulate(idx, axis=1, out=idx)
+        out = x[np.arange(idx.shape[0])[:, None], idx]
+        return out
+
+    # Reshape to [N * C, L] and fill the 2d tensor
+    N, L, C = data.size()
+    data_shaped = data.transpose(1, 2).reshape(-1, L).numpy()
+    data_fill = fill2d(data_shaped).reshape(-1, C, L)
+    data_out = torch.Tensor(data_fill).transpose(1, 2)
+
+    return data_out

--- a/torchcde/misc.py
+++ b/torchcde/misc.py
@@ -139,7 +139,9 @@ def forward_fill(x, fill_index=-2):
 
     mask = torch.isnan(x)
     if mask.any():
-        _, index = (~mask).cummax(dim=fill_index)
+        cumsum_mask = (~mask).cumsum(dim=fill_index)
+        cumsum_mask[mask] = 0
+        _, index = (cumsum_mask).cummax(dim=fill_index)
         x = x.gather(dim=fill_index, index=index)
 
     return x


### PR DESCRIPTION
Implemented functionality that enables `linear_interpolation_coeffs` to return the coefficients for a rectilinear interpolation. 

This involves a function `_prepare_rectilinear_interpolation` that converts a path of the form
```
[(t1, x1), (t2, NaN), (t3, x3), ...]
```
onto
```
[(t1, x1), (t2, x1), (t2, x1), (t3, x1), (t3, x3) ...]
```
such that linear interpolation on the modified path corresponds to rectilinear interpolation on the original path. 

This is invoked by supplying the index of the channel dimension where your time values belong (usually time_idx=0) as follows
```
    rectilinear_coeffs = linear_interpolation_coeffs(x, rectilinear=0)
```