### PR TITLE
Hermite cubic splines with backwards differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ We encourage looking at [time_series_classification.py](./example/time_series_cl
 Also see [irregular_data.py](./example/irregular_data.py), for demonstrations on how to handle variable-length inputs, irregular sampling, or missing data, all of which can be handled easily, without changing the model.
 
 A short self contained example:
+
 ```python
 import torch
 import torchcde
@@ -39,16 +40,19 @@ x = torch.cat([t_, x_], dim=2)  # include time as a channel
 
 # Interpolate it
 coeffs = torchcde.natural_cubic_coeffs(x)
-X = torchcde.NaturalCubicSpline(coeffs)
+X = torchcde.CubicSpline(coeffs)
+
 
 # Create the Neural CDE system
 class F(torch.nn.Module):
     def __init__(self):
         super(F, self).__init__()
-        self.linear = torch.nn.Linear(hidden_channels, 
+        self.linear = torch.nn.Linear(hidden_channels,
                                       hidden_channels * input_channels)
+
     def forward(self, t, z):
         return self.linear(z).view(batch, hidden_channels, input_channels)
+
 
 func = F()
 z0 = torch.rand(batch, hidden_channels)
@@ -123,19 +127,19 @@ coeffs = natural_cubic_coeffs(x)
 # coeffs is a torch.Tensor you can save, load,
 # pass through Datasets and DataLoaders etc.
 
-X = NaturalCubicSpline(coeffs)
+X = CubicSpline(coeffs)
 ```
 where:
 * `x` is a Tensor of shape `(..., length, input_channels)`, where `...` is some number of batch dimensions. Missing data should be represented as a `NaN`.
 
-The interface provided by `NaturalCubicSpline` is:
+The interface provided by `CubicSpline` is:
 
 * `.interval`, which gives the time interval the spline is defined over. (Often used as the `t` argument in `cdeint`.) This is determined implicitly from the length of the data, and so does _not_ in general correspond to the time your data was actually observed at. (See the [Further Documentation](#further-documentation) note on reparameterisation invariance.)
 * `.grid_points` is all of the knots in the spline, so that for example `X.evaluate(X.grid_points)` will recover the original data.
 * `.evaluate(t)`, where `t` is an any-dimensional Tensor, to evaluate the spline at any (collection of) time(s).
 * `.derivative(t)`, where `t` is an any-dimensional Tensor, to evaluate the derivative of the spline at any (collection of) time(s).
 
-Usually `natural_cubic_coeffs` should be computed as a preprocessing step, whilst `NaturalCubicSpline` should be called inside the forward pass of your model. See [time_series_classification.py](./example/time_series_classification.py) for a worked example.
+Usually `natural_cubic_coeffs` should be computed as a preprocessing step, whilst `CubicSpline` should be called inside the forward pass of your model. See [time_series_classification.py](./example/time_series_classification.py) for a worked example.
 
 Then call:
 ```python
@@ -164,21 +168,26 @@ We see that <img src="https://render.githubusercontent.com/render/math?math=%5Cw
 This ends up being a really useful fact for writing neater software. We can handle things like messy data (e.g. variable length time series) just during data preprocessing, without it complicating the model code. In [time_series_classification.py](/example/time_series_classification.py), the region we integrate over is given by `X.interval` as a standardised region to integrate over. In the example [irregular_data.py](/example/irregular_data.py), we use this to handle variable-length data.
 
 #### Different interpolation methods
+For a full breakdown into the interpolation schemes, see [Neural Controlled Differential Equations for Online Prediction Tasks](https://arxiv.org/pdf/2106.11028.pdf) where each interpolation scheme is scrutinised, and best practices are presented.
+
 In brief:
  * Do you need causality?
    * No: natural cubic splines.
    * Yes: Is your data multivariate with missing values?
-     * No: linear interpolation
      * Yes: rectilinear interpolation.
+     * No:
+       * Are you using an adaptive scheme?
+         * No: linear interpolation
+         * Yes: Hermite cubic splines with backwards differences
      
 In more detail:
-     
+
 * Natural cubic splines: the fastest approach.
 
 These were a simple choice used in the original Neural CDE paper. They are non-causal, but are very smooth, which makes them easy to integrate and thus fast to use in the differential equation solvers. These are usually the best choice if you don't need causality.
 ```python
 coeffs = natural_cubic_coeffs(x)
-X = NaturalCubicSpline(coeffs)
+X = CubicSpline(coeffs)
 cdeint(X=X, ...)
 ```
 
@@ -192,6 +201,18 @@ Linear interpolation has kinks. If using adaptive solvers then it should be told
 ```python
 coeffs = linear_interpolation_coeffs(x)
 X = LinearInterpolation(coeffs)
+cdeint(X=X, ...,
+       method='dopri5',
+       options=dict(jump_t=X.grid_points))
+```
+* Hermite cubic splines with backwards difference: these are "kind-of" causal in the same way as linear interpolation, but dont have kinks (making them faster with adaptive solvers).
+
+If you require one of the situations that natural cubic splines or linear interpolation are said to work for (non-causal or regular), then Hermite coefficients work like linear interpolation, but smooth the kinks, making them faster. Thay are less smooth than natural cubic coeffs, and therefore slower, but performance is generally better. 
+
+We recommend this scheme for most cases where causality is not a concern and you are using an adaptive solver. If causality is a concern and the data is irregular, use rectilinear interpolation. If you are not using an adaptive solver, use linear interpolation.
+```python
+coeffs = hermite_cubic_coefficients_with_backward_differences(x)
+X = CubicSpline(coeffs)
 cdeint(X=X, ...,
        method='dopri5',
        options=dict(jump_t=X.grid_points))

--- a/example/irregular_data.py
+++ b/example/irregular_data.py
@@ -26,7 +26,7 @@ def _solve_cde(x):
     # x should be a tensor of shape (..., length, channels), and may have missing data represented by NaNs.
 
     # Create dataset
-    coeffs = torchcde.natural_cubic_coeffs(x)
+    coeffs = torchcde.hermite_cubic_coefficients_with_backward_differences(x)
 
     # Create model
     input_channels = x.size(-1)
@@ -146,7 +146,7 @@ def irregular_data():
 
     ######################
     # Missing data is next. We indicated missing values by putting in some NaNs in `x`.
-    # Then when `natural_cubic_coeffs` is called inside `_solve_cde`, it just did the interpolation over the missing
+    # Then when `hermite_cubic_coefficients_with_backward_differences` is called inside `_solve_cde`, it just did the interpolation over the missing
     # values.
     ######################
 

--- a/example/irregular_data.py
+++ b/example/irregular_data.py
@@ -53,7 +53,7 @@ def _solve_cde(x):
             self.readout = torch.nn.Linear(hidden_channels, output_channels)
 
         def forward(self, coeffs):
-            X = torchcde.NaturalCubicSpline(coeffs)
+            X = torchcde.CubicSpline(coeffs)
             X0 = X.evaluate(X.interval[0])
             z0 = self.initial(X0)
             zt = torchcde.cdeint(X=X, func=self.func, z0=z0, t=X.interval)

--- a/example/time_series_classification.py
+++ b/example/time_series_classification.py
@@ -138,11 +138,11 @@ def main(num_epochs=30):
     optimizer = torch.optim.Adam(model.parameters())
 
     ######################
-    # Now we turn our dataset into a continuous path. We do this here via natural cubic spline interpolation.
+    # Now we turn our dataset into a continuous path. We do this here via Hermite cubic spline interpolation.
     # The resulting `train_coeffs` is a tensor describing the path.
     # For most problems, it's probably easiest to save this tensor and treat it as the dataset.
     ######################
-    train_coeffs = torchcde.natural_cubic_coeffs(train_X)
+    train_coeffs = torchcde.hermite_cubic_coefficients_with_backward_differences(train_X)
 
     train_dataset = torch.utils.data.TensorDataset(train_coeffs, train_y)
     train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=32)
@@ -157,7 +157,7 @@ def main(num_epochs=30):
         print('Epoch: {}   Training loss: {}'.format(epoch, loss.item()))
 
     test_X, test_y = get_data()
-    test_coeffs = torchcde.natural_cubic_coeffs(test_X)
+    test_coeffs = torchcde.hermite_cubic_coefficients_with_backward_differences(test_X)
     pred_y = model(test_coeffs).squeeze(-1)
     binary_prediction = (torch.sigmoid(pred_y) > 0.5).to(test_y.dtype)
     prediction_matches = (binary_prediction == test_y).to(test_y.dtype)

--- a/example/time_series_classification.py
+++ b/example/time_series_classification.py
@@ -65,7 +65,7 @@ class NeuralCDE(torch.nn.Module):
 
     def forward(self, coeffs):
         if self.interpolation == 'cubic':
-            X = torchcde.NaturalCubicSpline(coeffs)
+            X = torchcde.CubicSpline(coeffs)
         elif self.interpolation == 'linear':
             X = torchcde.LinearInterpolation(coeffs)
         else:

--- a/test/test_cdeint.py
+++ b/test/test_cdeint.py
@@ -25,7 +25,7 @@ def test_shape(backend, method, kwargs):
         values = torch.rand(*batch_dims, num_points, num_channels)
 
         coeffs = torchcde.natural_cubic_coeffs(values)
-        spline = torchcde.NaturalCubicSpline(coeffs)
+        spline = torchcde.CubicSpline(coeffs)
 
         class _Func(torch.nn.Module):
             def __init__(self):
@@ -49,7 +49,7 @@ def test_shape(backend, method, kwargs):
 def test_backend():
     x = torch.randn(1, 10, 2)
     coeffs = torchcde.natural_cubic_coeffs(x)
-    X = torchcde.NaturalCubicSpline(coeffs)
+    X = torchcde.CubicSpline(coeffs)
 
     def func(t, z):
         return -z.unsqueeze(-1).expand(1, 3, 2)
@@ -69,8 +69,8 @@ def test_tuple_input():
 
     coeffs_a = torchcde.natural_cubic_coeffs(xa)
     coeffs_b = torchcde.natural_cubic_coeffs(xb)
-    spline_a = torchcde.NaturalCubicSpline(coeffs_a)
-    spline_b = torchcde.NaturalCubicSpline(coeffs_b)
+    spline_a = torchcde.CubicSpline(coeffs_a)
+    spline_b = torchcde.CubicSpline(coeffs_b)
     X = torchcde.TupleControl(spline_a, spline_b)
 
     def func(t, z):
@@ -85,7 +85,7 @@ def test_tuple_input():
 
 def test_prod():
     x = torch.rand(2, 5, 1)
-    X = torchcde.NaturalCubicSpline(torchcde.natural_cubic_coeffs(x))
+    X = torchcde.CubicSpline(torchcde.natural_cubic_coeffs(x))
 
     class F:
         def prod(self, t, z, dXdt):

--- a/test/test_hermite_cubic.py
+++ b/test/test_hermite_cubic.py
@@ -35,4 +35,9 @@ def test_hermite_cubic_unit_time():
                 times = torch.linspace(0, length, 10)
                 for time in times:
                     fractional_part, index = spline._interpret_t(time)
-                    torch.allclose(spline.evaluate(time), hermite_cubic_unit.evaluate(fractional_part, index))
+                    print(spline.evaluate(time))
+                    print(hermite_cubic_unit.evaluate(fractional_part, index))
+                    assert torch.allclose(spline.evaluate(time), hermite_cubic_unit.evaluate(fractional_part, index))
+
+if __name__ == '__main__':
+    test_hermite_cubic_unit_time()

--- a/test/test_hermite_cubic.py
+++ b/test/test_hermite_cubic.py
@@ -1,8 +1,5 @@
 import torch
-from torchcde import (
-    hermite_cubic_coefficients_with_backward_differences,
-    HermiteCubicSplinesWithBackwardDifferences,
-)
+from torchcde import hermite_cubic_coefficients_with_backward_differences, CubicSpline
 
 
 # Represents a random Hermite cubic spline with unit time jumps
@@ -15,7 +12,7 @@ class _HermiteUnitTime:
         self._a = x_prev
         self._b = derivs_prev
         self._two_c = 2 * 2 * (derivs_next - derivs_prev)
-        self._three_d = - 3 * (derivs_next - derivs_prev)
+        self._three_d = -3 * (derivs_next - derivs_prev)
 
     def evaluate(self, fractional_part, index):
         fractional_part = fractional_part.unsqueeze(-1)
@@ -31,7 +28,7 @@ def test_hermite_cubic_unit_time():
                 data = torch.randn(*batch_dims, length, num_channels, dtype=torch.float64)
                 # Hermite
                 hermite_coeffs = hermite_cubic_coefficients_with_backward_differences(data)
-                spline = HermiteCubicSplinesWithBackwardDifferences(hermite_coeffs)
+                spline = CubicSpline(hermite_coeffs)
                 # Hermite with unit time
                 hermite_cubic_unit = _HermiteUnitTime(data)
                 # Test close

--- a/test/test_hermite_cubic.py
+++ b/test/test_hermite_cubic.py
@@ -1,0 +1,38 @@
+import torch
+import torchcde
+
+
+# Represents a random Hermite cubic spline
+class _HermiteCubic:
+    def __init__(self, batch_dims, num_channels, length=3):
+        self.data = torch.randn(*batch_dims, length, num_channels, dtype=torch.float64)
+        x_next = self.data[..., 1:, :]
+        x_prev = self.data[..., :-1, :]
+        delta_next = x_next - x_prev
+        delta_prev = x_next[..., 1:, :] - x_prev[..., :-1, :]
+
+        self.D = x_prev
+        self.C = delta_prev
+        self.B = 2 * (delta_next - delta_prev)
+        self.A = -(delta_next - delta_prev)
+
+    def _normalise_dims(self, t):
+        a = self.a
+        b = self.b
+        c = self.c
+        d1 = self.d1
+        d2 = self.d2
+        for _ in t.shape:
+            a = a.unsqueeze(-2)
+            b = b.unsqueeze(-2)
+            c = c.unsqueeze(-2)
+            d1 = d1.unsqueeze(-2)
+            d2 = d2.unsqueeze(-2)
+        t = t.unsqueeze(-1)
+        d = torch.where(t >= 0, d2, d1)
+        return a, b, c, d, t
+
+    def evaluate(self):
+
+
+if __name__ == '__main__':

--- a/test/test_natural_cubic_spline.py
+++ b/test/test_natural_cubic_spline.py
@@ -95,7 +95,7 @@ def test_interp():
                             values_slice[..., to_drop] = float('nan')
                             del num_drop, to_drop, values_slice
                     coeffs = interp_fn(values, t_)
-                    spline = torchcde.NaturalCubicSpline(coeffs, t_)
+                    spline = torchcde.CubicSpline(coeffs, t_)
                     _test_equal(batch_dims, num_channels, cubic, spline, torch.float64, start, end, 1e-3)
 
 
@@ -117,7 +117,7 @@ def test_linear():
                 t_ = None
             values = m * t.unsqueeze(-1) + c
             coeffs = interp_fn(values, t_)
-            spline = torchcde.NaturalCubicSpline(coeffs, t_)
+            spline = torchcde.CubicSpline(coeffs, t_)
             coeffs2 = torchcde.linear_interpolation_coeffs(values, t_)
             linear = torchcde.LinearInterpolation(coeffs2, t_)
             batch_dims = []
@@ -133,7 +133,7 @@ def test_short():
                 t = None
             values = torch.rand(2, 1)
             coeffs = interp_fn(values, t)
-            spline = torchcde.NaturalCubicSpline(coeffs, t)
+            spline = torchcde.CubicSpline(coeffs, t)
             coeffs2 = torchcde.linear_interpolation_coeffs(values, t)
             linear = torchcde.LinearInterpolation(coeffs2, t)
             batch_dims = []
@@ -179,7 +179,7 @@ def test_specification_and_derivative():
                         t = torch.linspace(0, length - 1, length, dtype=torch.float64)
                     x = torch.rand(*batch_dims, length, channels, dtype=torch.float64)
                     coeffs = interp_fn(x, t)
-                    spline = torchcde.NaturalCubicSpline(coeffs, t)
+                    spline = torchcde.CubicSpline(coeffs, t)
                     # Test specification
                     for i, point in enumerate(t):
                         evaluate = spline.evaluate(point)

--- a/test/test_tricks.py
+++ b/test/test_tricks.py
@@ -25,7 +25,7 @@ def test_grad_paths():
             t = torch.linspace(0, 9, 10, requires_grad=True)
             path = torch.rand(1, 10, 3, requires_grad=True)
             coeffs = torchcde.natural_cubic_coeffs(path, t)
-            cubic_spline = torchcde.NaturalCubicSpline(coeffs, t)
+            cubic_spline = torchcde.CubicSpline(coeffs, t)
             z0 = torch.rand(1, 3, requires_grad=True)
             func = _Func(input_size=3, hidden_size=3)
             t_ = torch.tensor([0., 9.], requires_grad=True)
@@ -67,7 +67,7 @@ def test_stacked_paths():
             return None, x
 
     coeff_paths = [(torchcde.linear_interpolation_coeffs, torchcde.LinearInterpolation),
-                   (torchcde.natural_cubic_coeffs, torchcde.NaturalCubicSpline)]
+                   (torchcde.natural_cubic_coeffs, torchcde.CubicSpline)]
     for adjoint in (False, True):
         for first_coeffs, First in coeff_paths:
             for second_coeffs, Second in coeff_paths:
@@ -111,7 +111,7 @@ def test_stacked_paths():
 # It's a bit superfluous to test it here now that we've upstreamed it into torchdiffeq, but oh well.
 def test_detach_trick():
     path = torch.rand(1, 10, 3)
-    interp = torchcde.NaturalCubicSpline(torchcde.natural_cubic_coeffs(path))
+    interp = torchcde.CubicSpline(torchcde.natural_cubic_coeffs(path))
 
     func = _Func(input_size=3, hidden_size=3)
 

--- a/torchcde/__init__.py
+++ b/torchcde/__init__.py
@@ -1,6 +1,10 @@
 from .interpolation_base import InterpolationBase
 from .interpolation_cubic import natural_cubic_spline_coeffs, natural_cubic_coeffs, NaturalCubicSpline
 from .interpolation_linear import linear_interpolation_coeffs, LinearInterpolation
+from .interpolation_hermite_cubic_bdiff import (
+    hermite_cubic_coefficients_with_backward_differences,
+    HermiteCubicSplinesWithBackwardDifferences,
+)
 from .log_ode import logsignature_windows, logsig_windows
 from .misc import TupleControl
 from .solver import cdeint

--- a/torchcde/__init__.py
+++ b/torchcde/__init__.py
@@ -1,10 +1,7 @@
 from .interpolation_base import InterpolationBase
-from .interpolation_cubic import natural_cubic_spline_coeffs, natural_cubic_coeffs, NaturalCubicSpline
+from .interpolation_cubic import natural_cubic_spline_coeffs, natural_cubic_coeffs, CubicSpline
 from .interpolation_linear import linear_interpolation_coeffs, LinearInterpolation
-from .interpolation_hermite_cubic_bdiff import (
-    hermite_cubic_coefficients_with_backward_differences,
-    HermiteCubicSplinesWithBackwardDifferences,
-)
+from .interpolation_hermite_cubic_bdiff import hermite_cubic_coefficients_with_backward_differences
 from .log_ode import logsignature_windows, logsig_windows
 from .misc import TupleControl
 from .solver import cdeint

--- a/torchcde/interpolation_cubic.py
+++ b/torchcde/interpolation_cubic.py
@@ -211,11 +211,11 @@ def natural_cubic_spline_coeffs(x, t=None):
         don't reinstantiate it on every forward pass, if at all possible.
 
     Returns:
-        A tensor, which should in turn be passed to `torchcde.NaturalCubicSpline`.
+        A tensor, which should in turn be passed to `torchcde.CubicSpline`.
 
         Why do we do it like this? Because typically you want to use PyTorch tensors at various interfaces, for example
         when loading a batch from a DataLoader. If we wrapped all of this up into just the
-        `torchcde.NaturalCubicSpline` class then that sort of thing wouldn't be possible.
+        `torchcde.CubicSpline` class then that sort of thing wouldn't be possible.
 
         As such the suggested use is to:
         (a) Load your data.
@@ -223,7 +223,7 @@ def natural_cubic_spline_coeffs(x, t=None):
         (c) Save the result.
         (d) Treat the result as your dataset as far as PyTorch's `torch.utils.data.Dataset` and
             `torch.utils.data.DataLoader` classes are concerned.
-        (e) Call NaturalCubicSpline as the first part of your model.
+        (e) Call CubicSpline as the first part of your model.
 
         See also the accompanying example.py.
     """
@@ -246,11 +246,11 @@ def natural_cubic_coeffs(x, t=None):
         don't reinstantiate it on every forward pass, if at all possible.
 
     Returns:
-        A tensor, which should in turn be passed to `torchcde.NaturalCubicSpline`.
+        A tensor, which should in turn be passed to `torchcde.CubicSpline`.
 
         Why do we do it like this? Because typically you want to use PyTorch tensors at various interfaces, for example
         when loading a batch from a DataLoader. If we wrapped all of this up into just the
-        `torchcde.NaturalCubicSpline` class then that sort of thing wouldn't be possible.
+        `torchcde.CubicSpline` class then that sort of thing wouldn't be possible.
 
         As such the suggested use is to:
         (a) Load your data.
@@ -258,22 +258,22 @@ def natural_cubic_coeffs(x, t=None):
         (c) Save the result.
         (d) Treat the result as your dataset as far as PyTorch's `torch.utils.data.Dataset` and
             `torch.utils.data.DataLoader` classes are concerned.
-        (e) Call NaturalCubicSpline as the first part of your model.
+        (e) Call CubicSpline as the first part of your model.
 
         See also the accompanying example.py.
     """
     return _natural_cubic_spline_coeffs(x, t, _version=1)
 
 
-class NaturalCubicSpline(interpolation_base.InterpolationBase):
-    """Calculates the natural cubic spline approximation to the batch of controls given. Also calculates its derivative.
+class CubicSpline(interpolation_base.InterpolationBase):
+    """Calculates the cubic spline approximation to the batch of controls given. Also calculates its derivative.
 
     Example:
         # (2, 1) are batch dimensions. 7 is the time dimension (of the same length as t). 3 is the channel dimension.
         x = torch.rand(2, 1, 7, 3)
         coeffs = natural_cubic_coeffs(x)
         # ...at this point you can save coeffs, put it through PyTorch's Datasets and DataLoaders, etc...
-        spline = NaturalCubicSpline(coeffs)
+        spline = CubicSpline(coeffs)
         point = torch.tensor(0.4)
         # will be a tensor of shape (2, 1, 3), corresponding to batch and channel dimensions
         out = spline.derivative(point)
@@ -286,7 +286,7 @@ class NaturalCubicSpline(interpolation_base.InterpolationBase):
             t: As passed to linear_interpolation_coeffs. (If it was passed. If you are using neural CDEs then you **do
                 not need to use this argument**. See the Further Documentation in README.md.)
         """
-        super(NaturalCubicSpline, self).__init__(**kwargs)
+        super(CubicSpline, self).__init__(**kwargs)
 
         if t is None:
             t = torch.linspace(0, coeffs.size(-2), coeffs.size(-2) + 1, dtype=coeffs.dtype, device=coeffs.device)
@@ -334,3 +334,21 @@ class NaturalCubicSpline(interpolation_base.InterpolationBase):
         inner = self._two_c[..., index, :] + self._three_d[..., index, :] * fractional_part
         deriv = self._b[..., index, :] + inner * fractional_part
         return deriv
+
+
+class NaturalCubicSpline(CubicSpline):
+    """Calculates the coefficients of the natural cubic spline approximation to the batch of controls given.
+
+    ********************
+    DEPRECATED: this now exists for backward compatibility. For new projects please use `CubicSpline` instead. This
+    class is general for any cubic coeffs (currently natural cubic or Hermite with backwards differences).
+    ********************
+    """
+    def __init__(self, coeffs, t=None, **kwargs):
+        """
+        Arguments:
+            coeffs: As returned by hermite_cubic_coefficients_with_backward_differences.
+            t: As passed to linear_interpolation_coeffs. (If it was passed. If you are using neural CDEs then you **do
+                not need to use this argument**. See the Further Documentation in README.md.)
+        """
+        super(NaturalCubicSpline, self).__init__(coeffs, t=t, **kwargs)

--- a/torchcde/interpolation_cubic.py
+++ b/torchcde/interpolation_cubic.py
@@ -1,6 +1,6 @@
 import torch
+from torchcde import interpolation_base
 
-from . import interpolation_base
 from . import misc
 
 
@@ -344,11 +344,3 @@ class NaturalCubicSpline(CubicSpline):
     class is general for any cubic coeffs (currently natural cubic or Hermite with backwards differences).
     ********************
     """
-    def __init__(self, coeffs, t=None, **kwargs):
-        """
-        Arguments:
-            coeffs: As returned by hermite_cubic_coefficients_with_backward_differences.
-            t: As passed to linear_interpolation_coeffs. (If it was passed. If you are using neural CDEs then you **do
-                not need to use this argument**. See the Further Documentation in README.md.)
-        """
-        super(NaturalCubicSpline, self).__init__(coeffs, t=t, **kwargs)

--- a/torchcde/interpolation_hermite_cubic_bdiff.py
+++ b/torchcde/interpolation_hermite_cubic_bdiff.py
@@ -1,5 +1,4 @@
 import torch
-from torchcde.interpolation_cubic import NaturalCubicSpline
 from torchcde.interpolation_linear import linear_interpolation_coeffs
 
 
@@ -47,14 +46,3 @@ def hermite_cubic_coefficients_with_backward_differences(x, t=None):
     return hermite_coeffs
 
 
-class HermiteCubicSplinesWithBackwardDifferences(NaturalCubicSpline):
-    """Calculates the cubic Hermite spline interpolation with backwards differences and its derivative."""
-
-    def __init__(self, coeffs, t=None, **kwargs):
-        """
-        Arguments:
-            coeffs: As returned by hermite_cubic_coefficients_with_backward_differences.
-            t: As passed to linear_interpolation_coeffs. (If it was passed. If you are using neural CDEs then you **do
-                not need to use this argument**. See the Further Documentation in README.md.)
-        """
-        super(HermiteCubicSplinesWithBackwardDifferences, self).__init__(coeffs, t=t, **kwargs)

--- a/torchcde/interpolation_hermite_cubic_bdiff.py
+++ b/torchcde/interpolation_hermite_cubic_bdiff.py
@@ -31,7 +31,7 @@ def hermite_cubic_coefficients_with_backward_differences(x, t=None):
 
         See the docstring for `torchcde.natural_cubic_coeffs` for more information on why we do it this way.
     """
-    # Lineaer coeffs
+    # Linear coeffs
     coeffs = linear_interpolation_coeffs(x, t=t, rectilinear=None)
 
     if t is None:

--- a/torchcde/interpolation_hermite_cubic_bdiff.py
+++ b/torchcde/interpolation_hermite_cubic_bdiff.py
@@ -1,0 +1,115 @@
+import torch
+from torchcde import interpolation_base
+from torchcde.interpolation_linear import linear_interpolation_coeffs
+
+
+def _setup_hermite_cubic_coeffs_w_backward_differences(times, coeffs, derivs, device=None):
+    """Compute the coefficients to smooth the linear interpolation."""
+    x_prev = coeffs[..., :-1, :]
+    x_next = coeffs[..., 1:, :]
+    # Let x_0 - x_{-1} = x_1 - x_0
+    derivs_prev = torch.cat((derivs[..., [0], :], derivs[..., :-1, :]), axis=-2)
+    derivs_next = derivs
+    x_diff = x_next - x_prev
+    t_diff = (times[1:] - times[:-1]).unsqueeze(-1)
+    # Coeffs
+    D = x_prev
+    C = derivs_prev
+    B = (1 / t_diff ** 2) * (3 * (x_diff - C * t_diff) - t_diff * (derivs_next - derivs_prev))
+    A = (1 / (3 * t_diff ** 2)) * (derivs_next - C - 2 * B * t_diff)
+    matching_coeffs = torch.stack([A, B, C, D]).permute(1, 2, 3, 0)
+    return matching_coeffs.to(device)
+
+
+def hermite_cubic_coefficients_with_backward_differences(x, t=None):
+    """Computes the coefficients for hermite cubic splines with backward differences.
+
+    Arguments:
+        See `linear_interpolation_coeffs` from `torchcde.interpolation.interpolation_linear`.
+
+    Returns:
+        A tensor, which should in turn be passed to `torchcde.HermiteCubicSplinesWithBackwardDifferences`.
+
+        See the docstring for `torchcde.natural_cubic_coeffs` for more information on why we do it this way.
+    """
+    # Lineaer coeffs
+    coeffs = linear_interpolation_coeffs(x, t=t, rectilinear=None)
+
+    # Linear derivs
+    derivs = (coeffs[..., 1:, :] - coeffs[..., :-1, :]) / (t[1:] - t[:-1]).unsqueeze(-1)
+
+    # Use the above to compute hermite coeffs
+    hermite_coeffs = _setup_hermite_cubic_coeffs_w_backward_differences(t, coeffs, derivs, device=coeffs.device)
+
+    return hermite_coeffs
+
+
+class HermiteCubicSplinesWithBackwardDifferences(interpolation_base.InterpolationBase):
+    """Calculates the cubic Hermite spline interpolation with backwards differences and its derivative."""
+
+    def __init__(self, coeffs, t=None):
+        """
+        Arguments:
+            coeffs: As returned by hermite_cubic_coefficients_with_backward_differences.
+            t: As passed to linear_interpolation_coeffs. (If it was passed. If you are using neural CDEs then you **do
+                not need to use this argument**. See the Further Documentation in README.md.)
+        """
+        super(HermiteCubicSplinesWithBackwardDifferences, self).__init__()
+
+        if t is None:
+            t = torch.linspace(0, coeffs.size(-2) - 1, coeffs.size(-2), dtype=coeffs.dtype, device=coeffs.device)
+
+        self.register_buffer("_t", t)
+        self.register_buffer("_coeffs", coeffs)
+
+    @property
+    def grid_points(self):
+        return self._t
+
+    @property
+    def interval(self):
+        return torch.stack([self._t[0], self._t[-1]])
+
+    def __len__(self):
+        return len(self.grid_points)
+
+    def _interpret_t(self, t):
+        t = torch.as_tensor(t, dtype=self._derivs.dtype, device=self._derivs.device)
+        maxlen = self._derivs.size(-2) - 1
+        # clamp because t may go outside of [t[0], t[-1]]; this is fine
+        index = torch.bucketize(t.detach(), self._t.detach()).sub(1).clamp(0, maxlen)
+        # will never access the last element of self._t; this is correct behaviour
+        fractional_part = t - self._t[index]
+        return fractional_part, index
+
+    @staticmethod
+    def _evaluate_matching_region(matching_coeffs, t, derivative=False):
+        """Evaluates the evaluation/derivative polynomials for the Hermite matching regions."""
+        device = matching_coeffs.device
+        if derivative:
+            t_powers = (
+                torch.tensor([i * t ** (i - 1) for i in range(1, matching_coeffs.size(-1))]).flip(dims=[0]).to(device)
+            )
+            evaluation = (matching_coeffs[..., :-1] * t_powers).sum(dim=-1)
+        else:
+            t_powers = torch.cat([t ** i for i in range(matching_coeffs.size(-1))]).flip(dims=[0]).to(device)
+            evaluation = (matching_coeffs * t_powers).sum(dim=-1)
+        return evaluation
+
+    def evaluate(self, t):
+        fractional_part, index = self._interpret_t(t)
+        coeffs = self.hermite_coeffs[:, index]
+        t_powers = torch.cat([fractional_part ** i for i in range(coeffs.size(-1))]).flip(dims=[0]).to(coeffs.device)
+        evaluation = (coeffs * t_powers).sum(dim=-1)
+        return evaluation
+
+    def derivative(self, t):
+        fractional_part, index = self._interpret_t(t)
+        coeffs = self.hermite_coeffs[:, index]
+        t_powers = (
+            torch.tensor([i * fractional_part ** (i - 1) for i in range(1, coeffs.size(-1))])
+            .flip(dims=[0])
+            .to(coeffs.device)
+        )
+        deriv = (coeffs[..., :-1] * t_powers).sum(dim=-1)
+        return deriv

--- a/torchcde/interpolation_hermite_cubic_bdiff.py
+++ b/torchcde/interpolation_hermite_cubic_bdiff.py
@@ -14,8 +14,8 @@ def _setup_hermite_cubic_coeffs_w_backward_differences(times, coeffs, derivs, de
     # Coeffs
     a = x_prev
     b = derivs_prev
-    c = (1 / t_diff ** 2) * (3 * (x_diff - b * t_diff) - t_diff * (derivs_next - derivs_prev))
-    d = (1 / (3 * t_diff ** 2)) * (derivs_next - b - 2 * c * t_diff)
+    c = 3 * (x_diff / t_diff ** 2 - b / t_diff) - (derivs_next - derivs_prev) / t_diff
+    d = (1 / (3 * t_diff ** 2)) * (derivs_next - b) - (2 * c) / (3 * t_diff)
     coeffs = torch.cat([a, b, 2 * c, 3 * d], dim=-1).to(device)
     return coeffs
 

--- a/torchcde/interpolation_hermite_cubic_bdiff.py
+++ b/torchcde/interpolation_hermite_cubic_bdiff.py
@@ -1,10 +1,10 @@
 import torch
-from torchcde import interpolation_base
+from torchcde.interpolation_cubic import NaturalCubicSpline
 from torchcde.interpolation_linear import linear_interpolation_coeffs
 
 
 def _setup_hermite_cubic_coeffs_w_backward_differences(times, coeffs, derivs, device=None):
-    """Compute the coefficients to smooth the linear interpolation."""
+    """Compute backward hermite from linear coeffs."""
     x_prev = coeffs[..., :-1, :]
     x_next = coeffs[..., 1:, :]
     # Let x_0 - x_{-1} = x_1 - x_0
@@ -13,12 +13,12 @@ def _setup_hermite_cubic_coeffs_w_backward_differences(times, coeffs, derivs, de
     x_diff = x_next - x_prev
     t_diff = (times[1:] - times[:-1]).unsqueeze(-1)
     # Coeffs
-    D = x_prev
-    C = derivs_prev
-    B = (1 / t_diff ** 2) * (3 * (x_diff - C * t_diff) - t_diff * (derivs_next - derivs_prev))
-    A = (1 / (3 * t_diff ** 2)) * (derivs_next - C - 2 * B * t_diff)
-    matching_coeffs = torch.stack([A, B, C, D]).permute(1, 2, 3, 0)
-    return matching_coeffs.to(device)
+    a = x_prev
+    b = derivs_prev
+    c = (1 / t_diff ** 2) * (3 * (x_diff - b * t_diff) - t_diff * (derivs_next - derivs_prev))
+    d = (1 / (3 * t_diff ** 2)) * (derivs_next - b - 2 * c * t_diff)
+    coeffs = torch.cat([a, b, 2 * c, 3 * d], dim=-1).to(device)
+    return coeffs
 
 
 def hermite_cubic_coefficients_with_backward_differences(x, t=None):
@@ -35,6 +35,9 @@ def hermite_cubic_coefficients_with_backward_differences(x, t=None):
     # Lineaer coeffs
     coeffs = linear_interpolation_coeffs(x, t=t, rectilinear=None)
 
+    if t is None:
+        t = torch.linspace(0, coeffs.size(-2) - 1, coeffs.size(-2), dtype=coeffs.dtype, device=coeffs.device)
+
     # Linear derivs
     derivs = (coeffs[..., 1:, :] - coeffs[..., :-1, :]) / (t[1:] - t[:-1]).unsqueeze(-1)
 
@@ -44,72 +47,14 @@ def hermite_cubic_coefficients_with_backward_differences(x, t=None):
     return hermite_coeffs
 
 
-class HermiteCubicSplinesWithBackwardDifferences(interpolation_base.InterpolationBase):
+class HermiteCubicSplinesWithBackwardDifferences(NaturalCubicSpline):
     """Calculates the cubic Hermite spline interpolation with backwards differences and its derivative."""
 
-    def __init__(self, coeffs, t=None):
+    def __init__(self, coeffs, t=None, **kwargs):
         """
         Arguments:
             coeffs: As returned by hermite_cubic_coefficients_with_backward_differences.
             t: As passed to linear_interpolation_coeffs. (If it was passed. If you are using neural CDEs then you **do
                 not need to use this argument**. See the Further Documentation in README.md.)
         """
-        super(HermiteCubicSplinesWithBackwardDifferences, self).__init__()
-
-        if t is None:
-            t = torch.linspace(0, coeffs.size(-2) - 1, coeffs.size(-2), dtype=coeffs.dtype, device=coeffs.device)
-
-        self.register_buffer("_t", t)
-        self.register_buffer("_coeffs", coeffs)
-
-    @property
-    def grid_points(self):
-        return self._t
-
-    @property
-    def interval(self):
-        return torch.stack([self._t[0], self._t[-1]])
-
-    def __len__(self):
-        return len(self.grid_points)
-
-    def _interpret_t(self, t):
-        t = torch.as_tensor(t, dtype=self._derivs.dtype, device=self._derivs.device)
-        maxlen = self._derivs.size(-2) - 1
-        # clamp because t may go outside of [t[0], t[-1]]; this is fine
-        index = torch.bucketize(t.detach(), self._t.detach()).sub(1).clamp(0, maxlen)
-        # will never access the last element of self._t; this is correct behaviour
-        fractional_part = t - self._t[index]
-        return fractional_part, index
-
-    @staticmethod
-    def _evaluate_matching_region(matching_coeffs, t, derivative=False):
-        """Evaluates the evaluation/derivative polynomials for the Hermite matching regions."""
-        device = matching_coeffs.device
-        if derivative:
-            t_powers = (
-                torch.tensor([i * t ** (i - 1) for i in range(1, matching_coeffs.size(-1))]).flip(dims=[0]).to(device)
-            )
-            evaluation = (matching_coeffs[..., :-1] * t_powers).sum(dim=-1)
-        else:
-            t_powers = torch.cat([t ** i for i in range(matching_coeffs.size(-1))]).flip(dims=[0]).to(device)
-            evaluation = (matching_coeffs * t_powers).sum(dim=-1)
-        return evaluation
-
-    def evaluate(self, t):
-        fractional_part, index = self._interpret_t(t)
-        coeffs = self.hermite_coeffs[:, index]
-        t_powers = torch.cat([fractional_part ** i for i in range(coeffs.size(-1))]).flip(dims=[0]).to(coeffs.device)
-        evaluation = (coeffs * t_powers).sum(dim=-1)
-        return evaluation
-
-    def derivative(self, t):
-        fractional_part, index = self._interpret_t(t)
-        coeffs = self.hermite_coeffs[:, index]
-        t_powers = (
-            torch.tensor([i * fractional_part ** (i - 1) for i in range(1, coeffs.size(-1))])
-            .flip(dims=[0])
-            .to(coeffs.device)
-        )
-        deriv = (coeffs[..., :-1] * t_powers).sum(dim=-1)
-        return deriv
+        super(HermiteCubicSplinesWithBackwardDifferences, self).__init__(coeffs, t=t, **kwargs)

--- a/torchcde/interpolation_hermite_cubic_bdiff.py
+++ b/torchcde/interpolation_hermite_cubic_bdiff.py
@@ -14,9 +14,9 @@ def _setup_hermite_cubic_coeffs_w_backward_differences(times, coeffs, derivs, de
     # Coeffs
     a = x_prev
     b = derivs_prev
-    c = 3 * (x_diff / t_diff ** 2 - b / t_diff) - (derivs_next - derivs_prev) / t_diff
-    d = (1 / (3 * t_diff ** 2)) * (derivs_next - b) - (2 * c) / (3 * t_diff)
-    coeffs = torch.cat([a, b, 2 * c, 3 * d], dim=-1).to(device)
+    two_c = 2 * (3 * (x_diff / t_diff - b) - derivs_next + derivs_prev) / t_diff
+    three_d = (1 / t_diff ** 2) * (derivs_next - b) - (two_c) / t_diff
+    coeffs = torch.cat([a, b, two_c, three_d], dim=-1).to(device)
     return coeffs
 
 
@@ -44,5 +44,3 @@ def hermite_cubic_coefficients_with_backward_differences(x, t=None):
     hermite_coeffs = _setup_hermite_cubic_coeffs_w_backward_differences(t, coeffs, derivs, device=coeffs.device)
 
     return hermite_coeffs
-
-

--- a/torchcde/solver.py
+++ b/torchcde/solver.py
@@ -152,7 +152,7 @@ def cdeint(X, func, z0, t, adjoint=True, backend="torchdiffeq", **kwargs):
 
     Arguments:
         X: The control. This should be a instance of `torch.nn.Module`, with a `derivative` method. For example
-            `torchcde.NaturalCubicSpline`. This represents a continuous path derived from the data. The
+            `torchcde.CubicSpline`. This represents a continuous path derived from the data. The
             derivative at a point will be computed via `X.derivative(t)`, where t is a scalar tensor. The returned
             tensor should have shape (..., input_channels), where '...' is some number of batch dimensions and
             input_channels is the number of channels in the input path.
@@ -216,7 +216,7 @@ def cdeint(X, func, z0, t, adjoint=True, backend="torchdiffeq", **kwargs):
                               "```\n"
                               "coeffs = ...\n"
                               "func = ...\n"
-                              "X = NaturalCubicSpline(coeffs)\n"
+                              "X = CubicSpline(coeffs)\n"
                               "adjoint_params = tuple(func.parameters()) + (coeffs,)\n"
                               "cdeint(X=X, func=func, ..., adjoint_params=adjoint_params)\n"
                               "```")


### PR DESCRIPTION
This PR implements Hermite cubic splines via backwards difference a la [Online Neural CDEs](https://arxiv.org/pdf/2106.11028.pdf). 

I added tests to ensure the coefficients are produced correctly. Turns out they can just utilise the `NaturalCubicSplines` class and so theres no need to reproduce those tests. 

I created a `HermiteCubicSplinesWithBackwardDifferences` class analogous to `NaturalCubicSplines`, however it is simply inheriting `NaturalCubicSplines`. One option would be to change `NaturalCubicSplines` -> `GeneralCubicSplines` or something and then both can utilise that class. 