### PR TITLE
Fix `_logsignature_windows` to avoid RuntimeError

### DIFF
--- a/torchcde/__init__.py
+++ b/torchcde/__init__.py
@@ -6,4 +6,4 @@ from .log_ode import logsignature_windows, logsig_windows
 from .misc import TupleControl
 from .solver import cdeint
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/torchcde/log_ode.py
+++ b/torchcde/log_ode.py
@@ -49,7 +49,7 @@ def _logsignature_windows(x, depth, window_length, t, _version):
     x = interpolation_linear.linear_interpolation_coeffs(x, t)
 
     # Flatten batch dimensions for compatibility with Signatory
-    flatten_X = x.view(-1, x.size(-2), x.size(-1))
+    flatten_X = x.reshape(-1, x.size(-2), x.size(-1))
     first_increment = torch.zeros(*batch_dimensions, signatory.logsignature_channels(x.size(-1), depth), dtype=x.dtype,
                                   device=x.device)
     first_increment[..., :x.size(-1)] = x[..., 0, :]


### PR DESCRIPTION
There is an error-prone code for flattening batch dimensions in the specific case like the following example:

- using batch dimensions as like `(64, 10)`.

Then the below `RuntimeError` has occurred:

```
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces).
```

The batch dimensions are closely related to the argument `x` in the DocString in the `linear_interpolation_coeffs` function. The DocString says:

> `x`: tensor of values, of shape `(..., length, input_channels)`, where `...` is some number of batch dimensions.


The above `RunTimeError` is the widespread error when we use `torch.view` function. 
There is no problem with the `torchcde` examples, but `torch.view` has the latent error in that case.


In this context, it seems that `torch.reshape` is more robust than `torch.view` and therefore I propose the request.
